### PR TITLE
added travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - '8.4.0'
+services:
+  - mongodb
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+env:
+  - CXX=g++-4.8
+sudo: required
+before_script: npm i
+script:
+  - npm test


### PR DESCRIPTION
travs is congured to use node v8.4.0
it will start mongodb and install dependencies and run npm test